### PR TITLE
Update library_api.py, don't get ID for debts

### DIFF
--- a/custom_components/bibliotek_dk/library_api.py
+++ b/custom_components/bibliotek_dk/library_api.py
@@ -652,7 +652,7 @@ class Library:
             obj = libraryDebt()
 
             # Get the first element (id)
-            obj.id = self._getIdInfo(material)[0]
+            # obj.id = self._getIdInfo(material)[0]
 
             # URL and image
             obj.url, obj.coverUrl = self._getMaterialUrls(material)


### PR DESCRIPTION
Not all libraries allow online settlement of debts and thus do not provide an input with the id. Don't try to get id for debts